### PR TITLE
Update the jackson version to 2.9.9

### DIFF
--- a/src/main/provisioning/sling-models-jacksonexporter.txt
+++ b/src/main/provisioning/sling-models-jacksonexporter.txt
@@ -18,7 +18,7 @@
 #
 [feature name=models-jacksonexporter]
 [variables]
-    jackson.version=2.9.7
+    jackson.version=2.9.9
 
 [artifacts]
   org.apache.sling/org.apache.sling.models.jacksonexporter/1.0.8


### PR DESCRIPTION
Let me know if there is another place or component this should be updated in. However, after changing the file I confirmed in the Web Console that the 2.9.9 version of the jackson-annotations, jackson-core and jackson-databind components are in use.