### PR TITLE
SLING-9397 Added install options for datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,28 @@ How to run the Sling Starter module in Standalone mode
         directory. It is advisable to use a work directory outside of the
         project directory.
 
-1) Build the Sling Starter using 
-
-	mvn clean install
+1) Build the Sling Starter using   
+        
+        mvn clean install
 	
 in the current directory.
 
 2) Start the generated jar with
 
-	 java -jar target/org.apache.sling.starter-10-SNAPSHOT.jar 
+        java -jar target/org.apache.sling.starter-12-SNAPSHOT.jar 
 	 
-Use the correct version number instead of 10-SNAPSHOT, if needed.
+Note: Use the correct version number instead of 12-SNAPSHOT, if needed.
+
+Use optional flags after the .jar
+Such as help using the `-h` flag
+   
+        java -jar org.apache.sling.starter-12-SNAPSHOT.jar -h
+
+or add Run Modes for example `-Dsling.run.modes=author,notshared,oak_tar,fds`
+* oak_mongo (DocumentStore)
+* oak_tar (SegmentStore)
+* oak_tar,fds (SegmentStore with a file datastore)
+* oak_mongo,fds (DocumentStore with a file datastore)
 
 3) Browse Sling in:
 

--- a/src/main/provisioning/boot.txt
+++ b/src/main/provisioning/boot.txt
@@ -25,7 +25,7 @@
 # oak_tar and oak_mongo run modes are mutually exclusive,
 # and cannot be changed after the first startup
 [settings]
-    sling.run.mode.install.options=oak_tar,oak_mongo
+    sling.run.mode.install.options=oak_tar,oak_mongo|nofds,fds
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index
 

--- a/src/main/provisioning/oak.txt
+++ b/src/main/provisioning/oak.txt
@@ -100,3 +100,17 @@
   org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreService
     mongouri="mongodb://localhost:27017"
     db="sling"
+
+[configurations runModes=fds]
+  org.apache.jackrabbit.oak.plugins.blob.datastore.FileDataStore
+    minRecordLength=I"4096"
+    path="sling/repository/datastore"
+    cacheSizeInMB=I"128"
+
+[configurations runModes=fds,oak_tar]
+  org.apache.jackrabbit.oak.segment.SegmentNodeStoreService
+    customBlobStore=B"true"
+
+[configurations runModes=fds,oak_mongo]
+  org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreService
+    customBlobStore=B"true"


### PR DESCRIPTION
Added mutually exclusive 'fds' and 'nofds' sling.run.mode.install.options, which can be combined with either oak_mongo or oak_tar to setup a file datastore. Updated Readme.md describing install options.