### PR TITLE
SLING-9786 - Use pre-authentication for system users

### DIFF
--- a/src/main/features/app/slingshot.json
+++ b/src/main/features/app/slingshot.json
@@ -9,12 +9,12 @@
     "configurations":{
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~sling.slingshot":{
             "user.mapping":[
-                "org.apache.sling.sample.slingshot=slingshot-service"
+                "org.apache.sling.sample.slingshot=[slingshot-service]"
             ]
         }
     },
     "repoinit:TEXT|true":[
-        "create service user slingshot-service",
+        "create service user slingshot-service with path system/sling",
         "create user slingshot1 with password slingshot1",
         "create user slingshot2 with password slingshot2",
         "",
@@ -23,7 +23,7 @@
         "create path (sling:Folder) /content/slingshot/users/slingshot1",
         "create path (sling:Folder) /content/slingshot/users/slingshot2",
         "",
-        "set ACL for slingshot-service",
+        "set principal ACL for slingshot-service",
         "allow   jcr:read,rep:write    on /content/slingshot",
         "end",
         "",

--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -286,46 +286,46 @@
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~i18n":{
             "user.mapping":[
-                "org.apache.sling.i18n=sling-i18n"
+                "org.apache.sling.i18n=[sling-readall]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~installer-factories":{
             "user.mapping":[
-                "org.apache.sling.installer.factory.packages=sling-package-install"
+                "org.apache.sling.installer.factory.packages=[sling-package-install]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~jcr-install":{
             "user.mapping":[
-                "org.apache.sling.installer.provider.jcr=sling-jcr-install"
+                "org.apache.sling.installer.provider.jcr=[sling-readall,sling-jcr-install]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~jcr-resource":{
             "user.mapping":[
-                "org.apache.sling.jcr.resource:validation=sling-readall"
+                "org.apache.sling.jcr.resource:validation=[sling-readall]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~observation":{
             "user.mapping":[
-                "org.apache.sling.jcr.resource:observation=sling-readall"
+                "org.apache.sling.jcr.resource:observation=[sling-readall]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~resourceresolver":{
             "user.mapping":[
-                "org.apache.sling.resourceresolver:mapping=sling-mapping",
-                "org.apache.sling.resourceresolver:hierarchy=sling-readall",
-                "org.apache.sling.resourceresolver:observation=sling-readall",
-                "org.apache.sling.resourceresolver:console=sling-readall"
+                "org.apache.sling.resourceresolver:mapping=[sling-readall]",
+                "org.apache.sling.resourceresolver:hierarchy=[sling-readall]",
+                "org.apache.sling.resourceresolver:observation=[sling-readall]",
+                "org.apache.sling.resourceresolver:console=[sling-readall]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~servletsresolver":{
             "user.mapping":[
-                "org.apache.sling.servlets.resolver:console=sling-readall",
-                "org.apache.sling.servlets.resolver:scripts=sling-scripting"
+                "org.apache.sling.servlets.resolver:console=[sling-readall]",
+                "org.apache.sling.servlets.resolver:scripts=[sling-search-path-reader]"
             ]
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~xss":{
             "user.mapping":[
-                "org.apache.sling.xss=sling-xss"
+                "org.apache.sling.xss=[sling-xss]"
             ]
         }
     },
@@ -336,53 +336,49 @@
         "allow   jcr:read   on /content",
         "end",
         "",
-        "# sling-mapping",
-        "create service user sling-mapping",
-        "",
-        "set ACL for sling-mapping",
-        "allow   jcr:read    on /",
-        "end",
-        "",
         "# sling-readall",
-        "create service user sling-readall",
+        "create service user sling-readall with path system/sling",
         "",
-        "set ACL for sling-readall",
+        "set principal ACL for sling-readall",
         "allow   jcr:read    on /",
         "end",
         "",
         "# sling-xss",
-        "create service user sling-xss",
+        "create service user sling-xss with path system/sling",
         "",
         "create path (sling:Folder) /apps/sling/xss",
         "",
-        "set ACL for sling-xss",
+        "set principal ACL for sling-xss",
         "allow   jcr:read    on /apps/sling/xss",
         "end",
         "",
-        "# sling-i18n",
-        "create service user sling-i18n",
-        "",
-        "set ACL for sling-i18n",
-        "allow   jcr:read    on /",
-        "end",
-        "",
         "# sling-jcr-install",
-        "create service user sling-jcr-install",
+        "create service user sling-jcr-install with path system/sling",
         "",
         "# used for config OSGi writeback",
         "create path (sling:Folder) /apps/sling/install",
         "",
-        "set ACL for sling-jcr-install",
-        "allow    jcr:read    on    /",
+        "set principal ACL for sling-jcr-install",
         "allow    rep:write    on /apps/sling/install",
         "end",
         "",
         "# content-package installer",
-        "create service user sling-package-install",
+        "create service user sling-package-install with path system/sling",
         "",
-        "set ACL for sling-package-install",
-        "allow    jcr:all     on    /",
+        "set principal ACL for sling-package-install",
+        "allow   jcr:all     on    /",
         "allow   jcr:namespaceManagement,jcr:nodeTypeDefinitionManagement on :repository",
-        "end"
+        "end",
+        "#<<< SLING-5848 - Define service user and ACLs for Scripting",
+        "create service user sling-search-path-reader with path system/sling",
+        "",
+        "create path (sling:Folder) /libs",
+        "create path (sling:Folder) /apps",
+        "",
+        "set principal ACL for sling-search-path-reader",
+        "allow   jcr:read    on /libs,/apps",
+        "end",
+        "# SLING-5848 - Define service user and ACLs for Scripting >>>"
+        
     ]
 }

--- a/src/main/features/caconfig.json
+++ b/src/main/features/caconfig.json
@@ -17,7 +17,7 @@
     "configurations":{
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~sling-caconfig":{
             "user.mapping":[
-                "org.apache.sling.caconfig.impl=sling-readall"
+                "org.apache.sling.caconfig.impl=[sling-readall]"
             ]
         }
     },

--- a/src/main/features/discovery.json
+++ b/src/main/features/discovery.json
@@ -25,19 +25,19 @@
     "configurations":{
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~sling.discovery":{
             "user.mapping":[
-                "org.apache.sling.discovery.commons=sling-discovery",
-                "org.apache.sling.discovery.base=sling-discovery",
-                "org.apache.sling.discovery.oak=sling-discovery"
+                "org.apache.sling.discovery.commons=[sling-discovery]",
+                "org.apache.sling.discovery.base=[sling-discovery]",
+                "org.apache.sling.discovery.oak=[sling-discovery]"
             ]
         }
     },
     "repoinit:TEXT|true":[
-        "create service user sling-discovery",
+        "create service user sling-discovery with path system/sling",
         "",
         "create path (sling:Folder) /var/discovery",
         "create path (sling:Folder) /var/discovery/oak",
         "",
-        "set ACL for sling-discovery",
+        "set principal ACL for sling-discovery",
         "allow   jcr:read,rep:write    on /var/discovery",
         "end"
     ]

--- a/src/main/features/event.json
+++ b/src/main/features/event.json
@@ -13,18 +13,18 @@
     "configurations":{
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~sling.event":{
             "user.mapping":[
-                "org.apache.sling.event=sling-event",
-                "org.apache.sling.event.dea=sling-event"
+                "org.apache.sling.event=[sling-event]",
+                "org.apache.sling.event.dea=[sling-event]"
             ]
         }
     },
     "repoinit:TEXT|true":[
-        "create service user sling-event",
+        "create service user sling-event with path system/sling",
         "",
         "create path (sling:Folder) /var",
         "create path (sling:Folder) /var/eventing",
         "",
-        "set ACL for sling-event",
+        "set principal ACL for sling-event",
         "allow   jcr:read,rep:write    on /var/eventing",
         "end"
     ]

--- a/src/main/features/scripting.json
+++ b/src/main/features/scripting.json
@@ -102,23 +102,10 @@
         },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~scripting":{
             "user.mapping":[
-                "org.apache.sling.scripting.core=sling-scripting",
-                "org.apache.sling.scripting.sightly.js.provider=sling-scripting",
-                "org.apache.sling.scripting.thymeleaf=sling-scripting"
+                "org.apache.sling.scripting.core=[sling-search-path-reader]",
+                "org.apache.sling.scripting.sightly.js.provider=[sling-search-path-reader]",
+                "org.apache.sling.scripting.thymeleaf=[sling-search-path-reader]"
             ]
         }
-    },
-    "repoinit:TEXT|true":[
-        "#<<< SLING-5848 - Define service user and ACLs for Scripting",
-        "create service user sling-scripting",
-        "",
-        "create path (sling:Folder) /libs",
-        "create path (sling:Folder) /apps",
-        "",
-        "set ACL for sling-scripting",
-        "deny    jcr:all     on /",
-        "allow   jcr:read    on /libs,/apps",
-        "end",
-        "# SLING-5848 - Define service user and ACLs for Scripting >>>"
-    ]
+    }
 }

--- a/src/main/features/validation.json
+++ b/src/main/features/validation.json
@@ -17,19 +17,8 @@
     "configurations":{
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~validation":{
             "user.mapping":[
-                "org.apache.sling.validation.core=sling-validation"
+                "org.apache.sling.validation.core=[sling-search-path-reader]"
             ]
         }
-    },
-    "repoinit:TEXT|true":[
-        "create service user sling-validation",
-        "",
-        "create path (sling:Folder) /apps",
-        "create path (sling:Folder) /libs",
-        "",
-        "set ACL for sling-validation",
-        "allow   jcr:read    on /apps",
-        "allow   jcr:read    on /libs",
-        "end"
-    ]
+    }
 }


### PR DESCRIPTION
Switch all system users to pre-authentication, and also collapse/rename
some duplicated service user definitions.