### PR TITLE
Re: SLING-9648 

### DIFF
--- a/src/main/features/boot.json
+++ b/src/main/features/boot.json
@@ -93,7 +93,7 @@
             "start-order":"1"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.settings:1.4.0",
+            "id":"org.apache.sling:org.apache.sling.settings:1.4.2",
             "start-order":"1"
         },
         {


### PR DESCRIPTION
Update Starter with version org.apache.sling.settings:1.4.2 to resolve errors described in SLING-9648