### PR TITLE
update of various outdated org.apache.sling dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jackrabbit.version>2.20.2</jackrabbit.version>
         <oak.version>1.38.0</oak.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <composum.nodes.version>2.3.0</composum.nodes.version>
+        <composum.nodes.version>2.6.1</composum.nodes.version>
         <jackson.version>2.12.1</jackson.version>
         <groovy.version>3.0.7</groovy.version>
         <!-- skip index generation for all builds except for CI and release -->
@@ -287,7 +287,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.utils</artifactId>
-            <version>1.11.6</version>
+            <version>1.11.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -70,7 +70,7 @@
             "start-order":"15"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.engine:2.7.2",
+            "id":"org.apache.sling:org.apache.sling.engine:2.7.4",
             "start-order":"20"
         },
         {
@@ -98,7 +98,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.resourceresolver:1.7.2",
+            "id":"org.apache.sling:org.apache.sling.resourceresolver:1.7.4",
             "start-order":"20"
         },
         {
@@ -118,7 +118,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.xss:2.2.8",
+            "id":"org.apache.sling:org.apache.sling.xss:2.2.12",
             "start-order":"20"
         },
         {
@@ -150,7 +150,7 @@
             "start-order":"5"
         },
         {
-            "id":"org.apache.felix:org.apache.felix.http.jetty:4.1.4",
+            "id":"org.apache.felix:org.apache.felix.http.jetty:4.1.6",
             "start-order":"5"
         },
         {
@@ -174,11 +174,19 @@
             "start-order":"5"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.auth.core:1.5.0",
+            "id":"org.apache.sling:org.apache.sling.auth.core:1.5.2",
             "start-order":"5"
         },
         {
             "id":"org.apache.sling:org.apache.sling.extensions.threaddump:0.2.2",
+            "start-order":"5"
+        },
+        {
+            "id":"io.dropwizard.metrics:metrics-core:3.2.6",
+            "start-order":"5"
+        },
+        {
+            "id":"org.apache.sling:org.apache.sling.commons.metrics:1.2.8",
             "start-order":"5"
         },
         {
@@ -206,14 +214,6 @@
             "start-order":"10"
         },
         {
-            "id":"io.dropwizard.metrics:metrics-core:3.2.6",
-            "start-order":"15"
-        },
-        {
-            "id":"org.apache.sling:org.apache.sling.commons.metrics:1.2.8",
-            "start-order":"15"
-        },
-        {
             "id":"org.apache.sling:org.apache.sling.resource.filter:1.0.0",
             "start-order":"15"
         },
@@ -222,7 +222,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.repoinit.parser:1.6.6",
+            "id":"org.apache.sling:org.apache.sling.repoinit.parser:1.6.8",
             "start-order":"20"
         },
         {

--- a/src/main/features/boot.json
+++ b/src/main/features/boot.json
@@ -133,7 +133,7 @@
             "start-order":"1"
         },
         {
-            "id":"org.apache.felix:org.apache.felix.scr:2.1.24",
+            "id":"org.apache.felix:org.apache.felix.scr:2.1.26",
             "start-order":"1"
         }
 


### PR DESCRIPTION
the following dependencies were outdated:

```
[INFO]   org.apache.sling:org.apache.sling.auth.core ........... 1.5.0 -> 1.5.2
[INFO]   org.apache.sling:org.apache.sling.engine .............. 2.7.2 -> 2.7.4
[INFO]   org.apache.sling:org.apache.sling.repoinit.parser ..... 1.6.6 -> 1.6.8
[INFO]   org.apache.sling:org.apache.sling.resourceresolver .... 1.7.2 -> 1.7.4
[INFO]   org.apache.sling:org.apache.sling.xss ................ 2.2.8 -> 2.2.12
[INFO]   com.composum.nodes:composum-nodes-commons ............. 2.3.0 -> 2.6.1
[INFO]   com.composum.nodes:composum-nodes-console ............. 2.3.0 -> 2.6.1
[INFO]   com.composum.nodes:composum-nodes-jslibs .............. 2.3.0 -> 2.6.1
[INFO]   com.composum.nodes:composum-nodes-pckgmgr ............. 2.3.0 -> 2.6.1
[INFO]   com.composum.nodes:composum-nodes-usermgr ............. 2.3.0 -> 2.6.1
[INFO]   org.apache.felix:org.apache.felix.http.jetty .......... 4.1.4 -> 4.1.6
[INFO]   org.apache.felix:org.apache.felix.scr ............... 2.1.24 -> 2.1.26
[INFO]   org.apache.felix:org.apache.felix.utils ............. 1.11.6 -> 1.11.8
```

also had to move org.apache.sling.commons.metrics and io.dropwizard.metrics:metrics-core from start-level 15 to start-level 5 to be able to build the project due to

```
[ERROR] org.apache.sling:org.apache.sling.auth.core:1.5.2:  is importing package(s) org.apache.sling.commons.metrics in start level 5 but no bundle is exporting these for that start level.
[ERROR] Analyser detected errors on feature 'org.apache.sling:org.apache.sling.starter:slingosgifeature:nosample_base:12-SNAPSHOT'. See log output for error messages.

```