### PR TITLE
SLING-10400 Update bundles in sling starter

### DIFF
--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -114,7 +114,11 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.servlets.resolver:2.7.12",
+            "id":"org.apache.sling:org.apache.sling.scripting.spi:1.0.2",
+            "start-order":"20"
+        },
+        {
+            "id":"org.apache.sling:org.apache.sling.servlets.resolver:2.7.14",
             "start-order":"20"
         },
         {

--- a/src/main/features/scripting.json
+++ b/src/main/features/scripting.json
@@ -14,7 +14,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.scripting.core:2.3.4",
+            "id":"org.apache.sling:org.apache.sling.scripting.core:2.3.6",
             "start-order":"20"
         },
         {
@@ -34,7 +34,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.scripting.jsp:2.5.0",
+            "id":"org.apache.sling:org.apache.sling.scripting.jsp:2.5.2",
             "start-order":"20"
         },
         {
@@ -58,7 +58,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.scripting.sightly:1.4.6-1.4.0",
+            "id":"org.apache.sling:org.apache.sling.scripting.sightly:1.4.8-1.4.0",
             "start-order":"20"
         },
         {


### PR DESCRIPTION
Update the sling starter to use the latest bundles changed by SLING-9999

Specifically updates to these:

[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   org.apache.sling:org.apache.sling.scripting.core ...... 2.3.4 -> 2.3.6
[INFO]   org.apache.sling:org.apache.sling.scripting.jsp ....... 2.5.0 -> 2.5.2
[INFO]   org.apache.sling:org.apache.sling.scripting.sightly ...
[INFO]                                               1.4.6-1.4.0 -> 1.4.8-1.4.0
[INFO]   org.apache.sling:org.apache.sling.servlets.resolver ...
[INFO]                                                         2.7.12 -> 2.7.14

And this new required bundle:

org.apache.sling:org.apache.sling.scripting.spi:1.0.2