### PR TITLE
SLING-10402 downgrade org.mongodb:mongo-java-driver to 3.8.2

### DIFF
--- a/src/main/features/oak/persistence/oak_persistence_mongods.json
+++ b/src/main/features/oak/persistence/oak_persistence_mongods.json
@@ -6,7 +6,7 @@
         },
         {
              // Do NOT blindly update this, see SLING-10402
-             "id":"org.mongodb:mongo-java-driver:3.12.7",
+             "id":"org.mongodb:mongo-java-driver:3.8.2",
              "start-order":"15"
          }
     ],


### PR DESCRIPTION
This solves problems connecting to MongoDB after the mongo-java-driver was upgraded. As @rombert [says in SLING-10402](https://issues.apache.org/jira/browse/SLING-10402?focusedCommentId=17348150&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17348150) :

_According to https://jackrabbit.apache.org/oak/docs/nodestore/document/mongo-document-store.html the version of Oak we use (1.38.0) supports MongoDB 4.0.x . Also according to https://github.com/apache/jackrabbit-oak/blob/651f1b96634268ea7285231cc85f40eda46fa01e/oak-parent/pom.xml#L57 , the version of the MongoDB driver we should use is 3.8.2 ._