### PR TITLE
SLING-10402 - run SmokeIT on both tar and mongo features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
         <groovy.version>3.0.7</groovy.version>
         <!-- skip index generation for all builds except for CI and release -->
         <bnd.index.generation.skip>true</bnd.index.generation.skip>
+
+        <!-- TODO remove this to get a dynamic mongo.port -->
+        <mongo.port>27017</mongo.port>
     </properties>
 
     <build>
@@ -182,7 +185,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- reserve a network port for the integration tests -->
+            <!-- reserve network ports for the integration tests -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -196,18 +199,8 @@
                         <configuration>
                             <portNames>
                                 <portName>http.port</portName>
-                            </portNames>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>reserve-network-port-mongo</id>
-                        <goals>
-                            <goal>reserve-network-port</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <portNames>
                                 <portName>http.port.mongo</portName>
+                                <portName>mongo.port</portName>
                             </portNames>
                         </configuration>
                     </execution>
@@ -230,11 +223,7 @@
                             <name>mongo:4.4.6</name>
                             <run>
                                 <ports>
-                                    <!--
-                                        TODO the local port should by dynamic for tests, but
-                                        currently the oak feature file hardcodes the default port
-                                    -->
-                                    <port>27017:27017</port>
+                                    <port>${mongo.port}:27017</port>
                                 </ports>
                                 <wait>
                                     <log>CONTROL</log>
@@ -296,6 +285,8 @@
                             <launcherArguments>
                                 <frameworkProperties>
                                     <org.osgi.service.http.port>${http.port.mongo}</org.osgi.service.http.port>
+                                    <!-- TODO this does not seem to work, for now mongo.port must be 27017 -->
+                                    <mongo.port>${mongo.port}</mongo.port>
                                 </frameworkProperties>
                             </launcherArguments>
                         </launch>

--- a/pom.xml
+++ b/pom.xml
@@ -199,9 +199,70 @@
                             </portNames>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>reserve-network-port-mongo</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>http.port.mongo</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
-            <!-- launch the oak_tar aggregate for the integration tests -->
+            <!--
+                Start a MongoDB container for the corresponding tests.
+                Must be declared before the feature-launcher-maven-plugin
+                so that the container is up before the corresponding Sling
+                instance starts.
+            -->
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.19.1</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>mongo</alias>
+                            <name>mongo:4.4.6</name>
+                            <run>
+                                <ports>
+                                    <!--
+                                        TODO the local port should by dynamic for tests, but
+                                        currently the oak feature file hardcodes the default port
+                                    -->
+                                    <port>27017:27017</port>
+                                </ports>
+                                <wait>
+                                    <log>CONTROL</log>
+                                    <time>60000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                    <stopMode>kill</stopMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-mongo</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-mongo</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- launch the Sling instances to test -->
             <plugin>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>feature-launcher-maven-plugin</artifactId>
@@ -220,6 +281,21 @@
                             <launcherArguments>
                                 <frameworkProperties>
                                     <org.osgi.service.http.port>${http.port}</org.osgi.service.http.port>
+                                </frameworkProperties>
+                            </launcherArguments>
+                        </launch>
+                        <launch>
+                            <id>sling-12-oak-mongo</id>
+                            <feature>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>oak_mongo</classifier>
+                                <type>slingosgifeature</type>
+                            </feature>
+                            <launcherArguments>
+                                <frameworkProperties>
+                                    <org.osgi.service.http.port>${http.port.mongo}</org.osgi.service.http.port>
                                 </frameworkProperties>
                             </launcherArguments>
                         </launch>
@@ -248,6 +324,7 @@
                <configuration>
                    <systemPropertyVariables>
                        <starter.http.port>${http.port}</starter.http.port>
+                       <starter.http.port.mongo>${http.port.mongo}</starter.http.port.mongo>
                        <starter.min.bundles.count>${starter.min.bundles.count}</starter.min.bundles.count>
                    </systemPropertyVariables>
                </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,6 @@
         <!-- skip index generation for all builds except for CI and release -->
         <bnd.index.generation.skip>true</bnd.index.generation.skip>
 
-        <!-- TODO remove this to get a dynamic mongo.port -->
-        <mongo.port>27017</mongo.port>
     </properties>
 
     <build>
@@ -255,7 +253,7 @@
             <plugin>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>feature-launcher-maven-plugin</artifactId>
-                <version>0.1.0</version>
+                <version>0.1.1-SNAPSHOT</version>
                 <configuration>
                     <launches>
                         <launch>
@@ -285,9 +283,10 @@
                             <launcherArguments>
                                 <frameworkProperties>
                                     <org.osgi.service.http.port>${http.port.mongo}</org.osgi.service.http.port>
-                                    <!-- TODO this does not seem to work, for now mongo.port must be 27017 -->
-                                    <mongo.port>${mongo.port}</mongo.port>
                                 </frameworkProperties>
+                                <variables>
+                                    <mongo.port>${mongo.port}</mongo.port>
+                                </variables>
                             </launcherArguments>
                         </launch>
                     </launches>

--- a/src/main/features/oak/persistence/oak_persistence_mongods.json
+++ b/src/main/features/oak/persistence/oak_persistence_mongods.json
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "mongo.port":"27017"
+    },
     "bundles":[
          {
              "id":"com.h2database:h2-mvstore:1.4.200",
@@ -13,7 +16,7 @@
     "configurations":{
         "org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreService":{
             "db":"sling",
-            "mongouri":"mongodb://localhost:27017"
+            "mongouri":"mongodb://localhost:${mongo.port}"
          }
     }
 }


### PR DESCRIPTION
These changes cause two Sling instances to be started for testing, with tar and mongo configs.

Docker services are required to run the mongo test.

I wasn't able to get the dynamic mongo port setup to work ,see TODO in pom.xml, I don't have time to dig deeper right now, if someone wants to have a look feel free!

Note also that the mongo container might not be stopped upon some types of test failures.