### PR TITLE
SLING-10402 skippable oak-mongo launch and test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <!-- skip index generation for all builds except for CI and release -->
         <bnd.index.generation.skip>true</bnd.index.generation.skip>
 
+        <!-- use to skip launching and testing sling-NN-oak-mongo if docker is not installed -->
+        <docker.skip>true</docker.skip>
     </properties>
 
     <build>
@@ -215,6 +217,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.19.1</version>
                 <configuration>
+                    <skip>${docker.skip}</skip>
                     <images>
                         <image>
                             <alias>mongo</alias>
@@ -273,6 +276,7 @@
                         </launch>
                         <launch>
                             <id>sling-12-oak-mongo</id>
+                            <skip>${docker.skip}</skip>
                             <feature>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>${project.artifactId}</artifactId>
@@ -316,6 +320,7 @@
                        <starter.http.port>${http.port}</starter.http.port>
                        <starter.http.port.mongo>${http.port.mongo}</starter.http.port.mongo>
                        <starter.min.bundles.count>${starter.min.bundles.count}</starter.min.bundles.count>
+                       <mongo.skip>${docker.skip}</mongo.skip>
                    </systemPropertyVariables>
                </configuration>
             </plugin>
@@ -373,6 +378,18 @@
             <properties>
                <bnd.index.generation.skip>false</bnd.index.generation.skip>
             </properties>
+        </profile>
+        <profile>
+            <id>enableDocker-linux</id>
+            <properties>
+                <docker.skip>false</docker.skip>
+            </properties>
+            <activation>
+                <!-- Activate on Linux systems. Assume presence of docker.pid file indicates Docker is available -->
+                <file>
+                    <exists>/var/run/docker.pid</exists>
+                </file>
+            </activation>
         </profile>
     </profiles>
 </project>

--- a/src/test/java/org/apache/sling/launchpad/SmokeIT.java
+++ b/src/test/java/org/apache/sling/launchpad/SmokeIT.java
@@ -45,7 +45,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,10 +66,18 @@ public class SmokeIT {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {"starter.http.port", 8080},
-            {"starter.http.port.mongo", 8081}
-        });
+        if (Boolean.getBoolean("mongo.skip")) {
+            // the mongo launcher was skipped so we
+            //  should not try to test it
+            return Arrays.asList(new Object[][] {
+                {"starter.http.port", 8080}
+            });
+        }  else {
+            return Arrays.asList(new Object[][] {
+                {"starter.http.port", 8080},
+                {"starter.http.port.mongo", 8081}
+            });
+        }
     }
 
     public SmokeIT(String propName, int defaultPort) {


### PR DESCRIPTION
skipped by default if docker install is not detected

Requires SLING-10423