### PR TITLE
SLING-10459 Update starter to use Oak 1.40.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- versions to be replaced in the feature files -->
         <asm.version>9.1</asm.version>
         <jackrabbit.version>2.20.2</jackrabbit.version>
-        <oak.version>1.38.0</oak.version>
+        <oak.version>1.40.0</oak.version>
         <slf4j.version>1.7.30</slf4j.version>
         <composum.nodes.version>2.6.1</composum.nodes.version>
         <jackson.version>2.12.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>                
+            </plugin>
             <!-- run the ITs -->
             <plugin>
                <artifactId>maven-failsafe-plugin</artifactId>
@@ -334,6 +334,9 @@
                    <systemPropertyVariables>
                        <starter.http.test.ports>false:${http.port},${docker.skip}:${http.port.mongo}</starter.http.test.ports>
                        <starter.min.bundles.count>${starter.min.bundles.count}</starter.min.bundles.count>
+                       <!-- Specify any number of starter.readable.N props for relative paths to check for a successful get request. -->
+                       <!-- Check the affected path for SLING-10402 regression checking -->
+                       <starter.readable.1>/slingshot/users/slingshot1/travel/home/images/home.jpg</starter.readable.1>
                    </systemPropertyVariables>
                </configuration>
             </plugin>

--- a/src/main/features/oak/persistence/oak_persistence_mongods.json
+++ b/src/main/features/oak/persistence/oak_persistence_mongods.json
@@ -8,8 +8,7 @@
              "start-order":"15"
         },
         {
-             // Do NOT blindly update this, see SLING-10402
-             "id":"org.mongodb:mongo-java-driver:3.8.2",
+             "id":"org.mongodb:mongo-java-driver:3.12.8",
              "start-order":"15"
          }
     ],

--- a/src/test/java/org/apache/sling/launchpad/SmokeIT.java
+++ b/src/test/java/org/apache/sling/launchpad/SmokeIT.java
@@ -18,9 +18,10 @@ package org.apache.sling.launchpad;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -197,6 +198,24 @@ public class SmokeIT {
                 Node nameAttr = attrs.getNamedItemNS("http://www.jcp.org/jcr/sv/1.0", "name");
                 assertThat("no 'name' attribute found", nameAttr, notNullValue());
                 assertThat("Invalid name attribute value", nameAttr.getNodeValue(), equalTo("content"));
+            }
+        }
+    }
+
+    /**
+     * For testing the SLING-10402 scenario
+     */
+    @Test
+    public void verifyReadableImage() throws Exception {
+        try ( CloseableHttpClient client = newClient() ) {
+            HttpGet get = new HttpGet("http://localhost:" + slingHttpPort + "/content/slingshot/users/slingshot1/travel/home/images/home.jpg");
+            try (CloseableHttpResponse response = client.execute(get, httpClientContext)) {
+                if ( response.getStatusLine().getStatusCode() != 200 ) {
+                    fail("Unexpected status line " + response.getStatusLine());
+                }
+                ByteArrayOutputStream bout = new ByteArrayOutputStream();
+                response.getEntity().writeTo(bout);
+                assertThat("Expected 1170194 bytes for image, but got " + bout.size(), bout.size(), equalTo(1170194));
             }
         }
     }


### PR DESCRIPTION
Also, update to org.mongodb:mongo-java-driver:3.12.8 which is now compatible with the oak release