### PR TITLE
Downgrade ANTLR to match Sling HTL Engine

### DIFF
--- a/src/main/features/scripting.json
+++ b/src/main/features/scripting.json
@@ -2,7 +2,7 @@
 {
     "bundles":[
         {
-            "id":"org.antlr:antlr4-runtime:4.9.1",
+            "id":"org.antlr:antlr4-runtime:4.7.1",
             "start-order":"20"
         },
         {


### PR DESCRIPTION
Opening http://localhost/htl/repl.html gives the following warning:

ANTLR Tool version 4.7.1 used for code generation does not match the current runtime version 4.9.1
ANTLR Runtime version 4.7.1 used for parser compilation does not match the current runtime version 4.9.1

This is caused by Sling HTL Engine being compiled with ANTLR 4.7.1. This is probably harmless (HTL works fine seemingly), but one static field was removed in antlr-runtime (no idea how important), so the versions are in principle not ABI compatible.