### PR TITLE
SLING-11140 Update bundles to the latest releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <artifact>org.apache.sling:org.apache.sling.feature.launcher:1.2.0</artifact>
+                            <artifact>org.apache.sling:org.apache.sling.feature.launcher:1.1.6</artifact>
                             <stripVersion>true</stripVersion>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Revert the feature launcher update since it immediately errors out:

Error: Unable to initialize main class org.apache.sling.feature.launcher.impl.Main
Caused by: java.lang.NoClassDefFoundError: org/apache/commons/cli/ParseException