### PR TITLE
SLING-11170 update to DS 1.5 compatible implementation of Felix SCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ See [Releasing a new version of the Sling starter](https://cwiki.apache.org/conf
 	
 in the current directory.
 
+Hint: You can defer stopping the instance after running the ITs with argument `-Dfeature-launcher.waitForInput=true` to do some manual checks.
+
 2) Start Sling backed by an Oak SegmentStore with
 
     java -jar target/dependency/org.apache.sling.feature.launcher.jar -f target/slingfeature-tmp/feature-oak_tar.json

--- a/src/main/features/boot.json
+++ b/src/main/features/boot.json
@@ -137,7 +137,7 @@
             "start-order":"1"
         },
         {
-            "id":"org.apache.felix:org.apache.felix.scr:2.1.30",
+            "id":"org.apache.felix:org.apache.felix.scr:2.2.0",
             "start-order":"1"
         }
 


### PR DESCRIPTION
Currently blocked by https://issues.apache.org/jira/browse/SLING-11173