### PR TITLE
SLING-11171 - WARN "The provided service user id 'serviceuser--org.apache.sling.auth.core' is not a known JCR system user id and therefore not allowed in the Sling Service User Mapper."

### DIFF
--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -300,6 +300,11 @@
             ],
             "whitelist.name":"sling"
         },
+        "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~auth-core":{
+            "user.mapping":[
+                "org.apache.sling.auth.core=[sling-readall]"
+            ]
+        },
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~i18n":{
             "user.mapping":[
                 "org.apache.sling.i18n=[sling-readall]"


### PR DESCRIPTION
Add a service user mapping for auth.core