### PR TITLE
SLING-11183 - Sling is starting up page no longer present

### DIFF
--- a/src/main/features/healthcheck.json
+++ b/src/main/features/healthcheck.json
@@ -87,7 +87,7 @@
                 "systemalive"
             ],
             "autoDisableFilter":true,
-            "responseTextFor503":"classpath:org.apache.sling.starter.content:content/content/startup/index.html"
+            "responseTextFor503":"classpath:org.apache.sling.starter.content:startup/index.html"
         },
         "org.apache.felix.hc.core.impl.servlet.HealthCheckExecutorServlet~default":{
             "servletPath":"/system/health"


### PR DESCRIPTION
Adjust the location of the startup page. Presumably this change was caused
by starter.content changes.