### PR TITLE
SLING-11193 - Configure the quartz scheduler with the known allowed thread pool names

### DIFF
--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -274,6 +274,11 @@
             "org.apache.sling.commons.log.level":"info",
             "org.apache.sling.commons.log.file":"logs/request.log"
         },
+        "org.apache.sling.commons.scheduler.impl.QuartzScheduler":{
+            "allowedPoolNames":[
+                "oak"
+            ]
+        },
         "org.apache.jackrabbit.vault.packaging.impl.PackagingImpl":{
             "authIdsForRootInstallation":[
                 "sling-package-install"


### PR DESCRIPTION
Allow a thread pool named 'oak'.