### PR TITLE
SLING-7935 - Move launchpad-testing module into the main starter repository

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,5 +1,12 @@
 {
     "jenkins": {
-        "emailRecipients": ["dev@sling.apache.org"]
+        "emailRecipients": ["dev@sling.apache.org"],
+        "sonarQubeEnabled": false,
+        "rebuildFrequency": "@daily",
+        "jdks": [8, 11, 17],
+        "additionalMavenParams": "-Dit.startTimeoutSeconds=120",
+        "archivePatterns": [
+            "**/logs/*.log"
+        ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ $ docker run --rm -p 8080:8080 -v sling-launcher:/opt/sling/launcher apache/slin
 
 The [docker/](docker/) directory contains sample files related to container-based development.
 
+## Testing
+
+The Sling Starter will execute two suites of tests using the `maven-surefire-plugin`:
+
+1. A small set of smoke tests, embedded in the project, that verify the basic functionality of the Starter
+1. An extensive set of end-to-end tests that verify the overall functionality of the Starter and the bundles that are embedded into it
+
+By default, these are both executed when building the project against an Oak SegmentNodeStore backend.
+
+Additionally, when the `ci` profile is enabled the smoke tests are also executed in against an Oak DocumentNodeStore backend. For technical resons, the full end-to-end tests are not executed.
+
 ## Building the Docker image
 
 This module can optionally build a Docker image. This is achieved by running a build with the `-Ddocker.skip=false` argument. By default, the image is built as `apache/sling:snapshot`. The tag can be overrriden using the `docker.label` Maven property.

--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,20 @@
                             <filesInclude>oak/*.json</filesInclude>
                             <title>Sling With No Samples and No Persistence</title>
                         </aggregate>
+                        <aggregate>
+                            <classifier>oak_tar_test</classifier>
+                            <filesInclude>*.json</filesInclude>
+                            <filesInclude>oak/*.json</filesInclude>
+                            <filesInclude>oak/persistence/oak_persistence_sns.json</filesInclude>
+                            <filesInclude>app/*.json</filesInclude>
+                            <filesInclude>test/*.json</filesInclude>
+                            <title>Sling with Oak Segment NS persistence and test content</title>
+                        </aggregate>
                     </aggregates>
                     <scans>
                         <scan>
                             <includeClassifier>oak_tar</includeClassifier>
+                            <includeClassifier>oak_tar_test</includeClassifier>
                             <includeClassifier>oak_mongo</includeClassifier>
                             <includeClassifier>nosample_base</includeClassifier>
                         </scan>
@@ -298,7 +308,7 @@
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>${project.artifactId}</artifactId>
                                 <version>${project.version}</version>
-                                <classifier>oak_tar</classifier>
+                                <classifier>oak_tar_test</classifier>
                                 <type>slingosgifeature</type>
                             </feature>
                             <launcherArguments>
@@ -351,7 +361,20 @@
                    </execution>
                </executions>
                <configuration>
+                   <dependenciesToScan>
+                       <dependency>org.apache.sling:org.apache.sling.launchpad.integration-tests</dependency>
+                   </dependenciesToScan>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>${failsafe.exclude}</exclude>
+                        <!-- Don't run provisioning model ITs in the feature model context -->
+                        <exclude>org/apache/sling/launchpad/webapp/integrationtest/provisioning/**.java</exclude>
+                    </excludes>
                    <systemPropertyVariables>
+                       <launchpad.http.server.url>http://localhost:${http.port}/</launchpad.http.server.url>
                        <starter.http.test.ports>false:${http.port},${docker.skip}:${http.port.mongo}</starter.http.test.ports>
                        <starter.min.bundles.count>${starter.min.bundles.count}</starter.min.bundles.count>
                        <!-- Comma-separated list of paths to check for 200 status (added for SLING-10402) -->
@@ -404,6 +427,19 @@
             <version>1.11.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+             <groupId>org.apache.sling</groupId>
+             <artifactId>org.apache.sling.launchpad.integration-tests</artifactId>
+             <version>${project.version}</version>
+             <scope>test</scope>
+        </dependency>
+        <!-- provided-scope dependency of the commons.johnzon bundle -->
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-core</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <profiles>
@@ -426,6 +462,20 @@
                <bnd.index.generation.skip>false</bnd.index.generation.skip>
                <docker.skip>false</docker.skip>
             </properties>
+            <!-- workaround for https://github.com/bndtools/bnd/issues/5247 -->
+            <repositories>
+                <repository>
+                    <id>Nexus</id>
+                    <name>Nexus</name>
+                    <url>https://repository.apache.org/snapshots/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
 </project>

--- a/src/main/features/test/junit.json
+++ b/src/main/features/test/junit.json
@@ -1,0 +1,27 @@
+{
+  "id":"${project.groupId}:${project.artifactId}:slingosgifeature:junit:${project.version}",  
+  "bundles":[
+    {
+      "id": "org.apache.sling:org.apache.sling.junit.core:1.0.26",
+      "start-order": "25"
+    },
+    {
+      "id": "org.apache.sling:org.apache.sling.junit.remote:1.0.12",
+      "start-order": "25"
+    },
+    {
+      "id": "org.apache.sling:org.apache.sling.junit.scriptable:1.0.12",
+      "start-order": "25"
+    }
+  ],
+  "configurations": {
+    "org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment~junit": {
+      "whitelist.bundles": [
+        "org.apache.sling.junit.core",
+        "org.apache.sling.junit.remote",
+        "org.apache.sling.junit.scriptable"
+      ],
+      "whitelist.name" :"junit"
+    }
+  }
+}

--- a/src/main/features/test/test-content-repoinit.txt
+++ b/src/main/features/test/test-content-repoinit.txt
@@ -1,0 +1,25 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+create path /repoinit/provisioningModelTest
+create service user provisioningModelUser
+create path (sling:OrderedFolder) /ANON_CAN_READ
+set ACL for everyone
+    allow jcr:read on /ANON_CAN_READ
+end

--- a/src/main/features/test/test-content.json
+++ b/src/main/features/test/test-content.json
@@ -1,0 +1,28 @@
+{
+  "id":"${project.groupId}:${project.artifactId}:slingosgifeature:test-content:${project.version}",  
+  "bundles":[
+    {
+      "id": "org.apache.sling:org.apache.sling.launchpad.test-fragment:13-SNAPSHOT",
+      "start-order": "25"
+    },
+    {
+      "id": "org.apache.sling:org.apache.sling.launchpad.test-services:13-SNAPSHOT",
+      "start-order": "25"
+    }
+  ],
+  "configurations": {
+    "org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment~test-content": {
+      "whitelist.bundles": [
+        "org.apache.sling.launchpad.test-services"
+      ],
+      "whitelist.name" :"test-content"
+    },
+    "org.apache.sling.servlets.resolver.SlingServletResolver": {
+      "servletresolver.cacheSize": 0
+    },
+    "integrationTestsConfig": {
+      "message": "This test config should be loaded at startup"
+    }
+  },
+  "repoinit:TEXT|true":"@file"
+}


### PR DESCRIPTION
Execute the launchpad-testing test suite in the regular starter build.