### PR TITLE
Update the default MognoDB port

### DIFF
--- a/src/main/features/oak/persistence/oak_persistence_mongods.json
+++ b/src/main/features/oak/persistence/oak_persistence_mongods.json
@@ -12,7 +12,7 @@
     "configurations":{
         "org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreService":{
             "db":"sling",
-            "mongouri":"mongodb://$[env:MONGODB_HOST;default=localhost]:$[env:MONGODB_PORT;type=Integer;default=27107]"
+            "mongouri":"mongodb://$[env:MONGODB_HOST;default=localhost]:$[env:MONGODB_PORT;type=Integer;default=27017]"
          }
     }
 }


### PR DESCRIPTION
Fixing small typo.
The default port for MongoDB is `27017` (https://www.mongodb.com/docs/manual/reference/default-mongodb-port/).