### PR TITLE
SLING-11585 Invalid config for the sling-event thread pool factory

### DIFF
--- a/src/main/features/event.json
+++ b/src/main/features/event.json
@@ -19,8 +19,8 @@
         },
         "org.apache.sling.commons.threads.impl.DefaultThreadPool.factory~sling-event":{
             "name":"org-apache-sling-event",
-            "maxPoolSize:Integer":"1",
-            "minPoolSize:Integer":"5"
+            "minPoolSize:Integer":"1",
+            "maxPoolSize:Integer":"5"
         }
     },
     "repoinit:TEXT|true": "@file"


### PR DESCRIPTION
In the starter event.json, the sling-event thread pool factory has an invalid configuration that results in an IllegalArgumentException getting thrown at runtime.  This causes all the scheduled jobs to not get triggered.

Specifically, the maxPoolSize is smaller than the minPoolSize