### PR TITLE
SLING-11701 - Starter CI builds are sometimes failing with an error about a conflict with the docker container name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,13 +272,6 @@
                                 </wait>
                             </run>
                         </image>
-                        <image>
-                            <name>apache/sling:${docker.label}</name>
-                            <build>
-                                <dockerFile>Dockerfile</dockerFile>
-                                <contextDir>${project.basedir}</contextDir>
-                            </build>
-                        </image>
                     </images>
                     <stopMode>kill</stopMode>
                 </configuration>
@@ -305,6 +298,18 @@
                         <goals>
                             <goal>build</goal>
                         </goals>
+                        <configuration>
+                            <!-- Configure the sling image only for build, we don't want to run it  -->
+                            <images>
+                                <image>
+                                    <name>apache/sling:${docker.label}</name>
+                                    <build>
+                                        <dockerFile>Dockerfile</dockerFile>
+                                        <contextDir>${project.basedir}</contextDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,7 @@
                 <version>0.39.0</version>
                 <configuration>
                     <skip>${docker.skip}</skip>
+                    <containerNamePattern>%e</containerNamePattern>
                     <images>
                         <image>
                             <alias>mongo</alias>


### PR DESCRIPTION
Use random container names to prevent naming conflicts while running CI builds concurrently.