### PR TITLE
SLING-11840 - Drop Java 8 support for the Sling Starter

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -3,7 +3,7 @@
         "emailRecipients": ["dev@sling.apache.org"],
         "sonarQubeEnabled": false,
         "rebuildFrequency": "@daily",
-        "jdks": [8, 11, 17],
+        "jdks": [11, 17],
         "additionalMavenParams": "-Dit.startTimeoutSeconds=120",
         "archivePatterns": [
             "**/logs/*.log"

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </scm>
 
     <properties>
-        <sling.java.version>8</sling.java.version>
+        <sling.java.version>11</sling.java.version>
         <starter.min.bundles.count>126</starter.min.bundles.count>
         <sling.feature.launcher.version>1.3.0</sling.feature.launcher.version>
 


### PR DESCRIPTION
- set sling.java.version to 11
- only build with Java 11 and Java 17 on Jenkins