### PR TITLE
SLING-11836 - Add Jakarta JSON support to the Sling Starter

### DIFF
--- a/src/main/features/boot.json
+++ b/src/main/features/boot.json
@@ -93,6 +93,10 @@
             "start-order":"1"
         },
         {
+          "id": "org.glassfish.hk2:osgi-resource-locator:2.5.0-b42",
+          "start-order": "1"
+        },
+        {
             "id":"org.apache.sling:org.apache.sling.commons.osgi:2.4.2",
             "start-order":"1"
         },


### PR DESCRIPTION
Add the glassfish osgi resource locator to the boot feature. This shim is explicitly invoked by the JsonProvider to properly function in OSGi environments [1].

[1]: https://github.com/jakartaee/jsonp-api/blob/a75c9ab8455c4d04b787a6eb18fde5b855ba632c/api/src/main/java/jakarta/json/spi/JsonProvider.java#L616-L645