### PR TITLE
Revert "chore(deps): update dependency io.fabric8:docker-maven-plugin to v0.43.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.43.2</version>
+                <version>0.43.0</version>
                 <configuration>
                     <skip>${docker.skip}</skip>
                     <containerNamePattern>%e</containerNamePattern>


### PR DESCRIPTION
This reverts commit 98a87a8edc2e9044fa730ebf93d792a0ac7aab49.

Version 0.43.2 has broken DockerHub pushes, see https://github.com/fabric8io/docker-maven-plugin/issues/1698