### PR TITLE
Exclude the xmlParserAPIs dependency from the classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,6 +525,12 @@
              <artifactId>org.apache.sling.launchpad.integration-tests</artifactId>
              <version>${project.version}</version>
              <scope>test</scope>
+             <exclusions>
+                 <exclusion>
+                     <groupId>xerces</groupId>
+                     <artifactId>xmlParserAPIs</artifactId>
+                 </exclusion>
+             </exclusions>
         </dependency>
         <!-- provided-scope dependency of the commons.johnzon bundle -->
         <dependency>


### PR DESCRIPTION
With moving to Java 11 as a baseline, these classes are seens as conflicting with the ones provided by the JDK:

The package javax.xml.parsers is accessible from more than one module: <unnamed>, java.xml