### PR TITLE
update apache jackrabbit, oak and related

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <!-- renovate: depName=org.ow2.asm:asm -->
         <asm.version>9.6</asm.version>
         <!-- renovate: depName=org.apache.jackrabbit:jackrabbit-jcr-commons -->
-        <jackrabbit.version>2.20.11</jackrabbit.version>
+        <jackrabbit.version>2.20.12</jackrabbit.version>
         <!-- renovate: depName=org.apache.jackrabbit:oak-api -->
-        <oak.version>1.54.0</oak.version>
+        <oak.version>1.56.0</oak.version>
         <!-- renovate: depName=org.slf4j:slf4j-api -->
         <slf4j.version>1.7.36</slf4j.version>
         <!-- renovate: depName=com.composum.nodes:composum-nodes-commons -->

--- a/src/main/features/maintenance.json
+++ b/src/main/features/maintenance.json
@@ -1,5 +1,5 @@
 {
     "prototype": {
-        "id": "org.apache.sling:org.apache.sling.jcr.maintenance:slingosgifeature:base:1.0.2"
+        "id": "org.apache.sling:org.apache.sling.jcr.maintenance:slingosgifeature:base:1.1.0"
     }
 }

--- a/src/main/features/oak/oak_base.json
+++ b/src/main/features/oak/oak_base.json
@@ -122,7 +122,7 @@
             "start-order":"15"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.jcr.oak.server:1.3.0",
+            "id":"org.apache.sling:org.apache.sling.jcr.oak.server:1.4.0",
             "start-order":"16"
         },
         {


### PR DESCRIPTION
bump oak-* to 1.56.0
bump jackrabbit-* to 2.20.12
bump o.a.sling.jcr.maintenance to 1.1.0
bump o.a.sling.jcr.oak.server to 1.4.0