### PR TITLE
SLING-12101 - Remove Guava from the Starter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,10 +35,6 @@
        "allowedVersions": "/^[0-9]+\\.[0-9]*[02468]+\\.[0-9]+$/"
      },
      {
-       "matchPackagePatterns": [ "guava" ],
-        "enabled": false
-     },
-     {
        "matchManagers": ["maven"],
        "matchDepTypes": ["provided"],
        "enabled": false

--- a/src/main/features/oak/oak_base.json
+++ b/src/main/features/oak/oak_base.json
@@ -6,10 +6,6 @@
             "start-order":"10"
         },
         {
-            "id":"com.google.guava:guava:15.0",
-            "start-order":"15"
-        },
-        {
             "id":"org.apache.jackrabbit:jackrabbit-data:${jackrabbit.version}",
             "start-order":"15"
         },


### PR DESCRIPTION
Remove the bundle from the Starter and drop the no longer needed Renovate config. Oak now uses its own private copy of Guava.