### PR TITLE
SLING-12117 - Moving ServiceUnavailableFilter~startupandshutdown to app/starter feature

### DIFF
--- a/src/main/features/app/starter.json
+++ b/src/main/features/app/starter.json
@@ -4,5 +4,19 @@
             "id":"org.apache.sling:org.apache.sling.starter.content:1.0.12",
             "start-order":"20"
         }
-    ]
+    ],
+    "configurations": {
+        "org.apache.felix.hc.core.impl.filter.ServiceUnavailableFilter~startupandshutdown":{
+            "osgi.http.whiteboard.filter.regex":"(?!/system/).*",
+            "avoid404DuringStartup":true,
+            "service.ranking:Integer":"2147483647",
+            "includeExecutionResult":false,
+            "osgi.http.whiteboard.context.select":"(osgi.http.whiteboard.context.name=*)",
+            "tags":[
+                "systemalive"
+            ],
+            "autoDisableFilter":true,
+            "responseTextFor503":"classpath:org.apache.sling.starter.content:startup/index.html"
+        }
+    }
 }

--- a/src/main/features/healthcheck.json
+++ b/src/main/features/healthcheck.json
@@ -83,18 +83,6 @@
                 "system-resources"
             ]
         },
-        "org.apache.felix.hc.core.impl.filter.ServiceUnavailableFilter~startupandshutdown":{
-            "osgi.http.whiteboard.filter.regex":"(?!/system/).*",
-            "avoid404DuringStartup":true,
-            "service.ranking:Integer":"2147483647",
-            "includeExecutionResult":false,
-            "osgi.http.whiteboard.context.select":"(osgi.http.whiteboard.context.name=*)",
-            "tags":[
-                "systemalive"
-            ],
-            "autoDisableFilter":true,
-            "responseTextFor503":"classpath:org.apache.sling.starter.content:startup/index.html"
-        },
         "org.apache.felix.hc.core.impl.servlet.HealthCheckExecutorServlet~default":{
             "servletPath":"/system/health",
 	    "servletContextName":"org.osgi.service.http"


### PR DESCRIPTION
The configuration 
`org.apache.felix.hc.core.impl.filter.ServiceUnavailableFilter~startupandshutdown` found in `src/main/features/healthcheck.json` references the starter content in its `responseTestFor503` property which will cause the model to fail to build if the starter content is not included in the aggregated feature model.
 
To keep the Starter Content-related features together, I suggest moving this configuration to `src/main/features/app/starter.json`