### PR TITLE
SLING-12154 - Add Generic Proxy configuration for Composum Health Checks

### DIFF
--- a/src/main/features/app/composum.json
+++ b/src/main/features/app/composum.json
@@ -30,6 +30,27 @@
                 "com.composum.nodes.usermgr"
             ],
             "whitelist.name":"composum"
+        },
+        "com.composum.sling.core.proxy.GenericProxyRequest~health": {
+          "tags.to.strip":[
+            "body"
+          ],
+          "name":"System Health",
+          "XSLT.chain.paths":[
+          ],
+          "tags.to.rename":[
+            "html:div"
+          ],
+          "targetUrl":"",
+          "tags.to.drop":[
+            "head",
+            "style",
+            "script",
+            "link"
+          ],
+          "referencePath":"/",
+          "enabled":true,
+          "targetPattern":"/system/health.*"
         }
     }
 }


### PR DESCRIPTION
Currently returns a 404 due to the proxy not being configured.