### PR TITLE
SLING-11836 : Add Jakarta JSON support to the Sling Starter

### DIFF
--- a/src/main/features/boot.json
+++ b/src/main/features/boot.json
@@ -174,8 +174,6 @@
         "felix.systempackages.substitution":"true",
         "sling.fileinstall.dir":"${sling.home}/install",
         "sling.fileinstall.dir.autocreate":"true",
-        "felix.cm.config.plugins": "org.apache.felix.configadmin.plugin.interpolation",
-        "org.apache.aries.spifly.auto.consumers":"jakarta.json-api",
-        "org.apache.aries.spifly.auto.providers": "org.eclipse.parsson"
+        "felix.cm.config.plugins": "org.apache.felix.configadmin.plugin.interpolation"
     }
 }


### PR DESCRIPTION
Remove org.apache.aries.spifly.auto.* framework properties that are no longer in use after commit 31e6d31.