### PR TITLE
SLING-12535 Remove fragment bundle test

### DIFF
--- a/src/main/features/test/test-content.json
+++ b/src/main/features/test/test-content.json
@@ -2,10 +2,6 @@
   "id":"${project.groupId}:${project.artifactId}:slingosgifeature:test-content:${project.version}",  
   "bundles":[
     {
-      "id": "org.apache.sling:org.apache.sling.launchpad.test-fragment:13-SNAPSHOT",
-      "start-order": "25"
-    },
-    {
       "id": "org.apache.sling:org.apache.sling.launchpad.test-services:13-SNAPSHOT",
       "start-order": "25"
     }


### PR DESCRIPTION
depends on https://github.com/apache/sling-org-apache-sling-launchpad-integration-tests/pull/21