### PR TITLE
SLING-12600 - Starter builds are flaky on Windows nodes: org.apache.sling.launchpad.webapp.integrationtest.NodetypeRenderingTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -586,6 +586,7 @@
             </activation>
             <properties>
                 <docker.skip>true</docker.skip>
+                <failsafe.exclude>**/NodetypeRenderingTest.java</failsafe.exclude>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Temporarily disable the Flaky test on Jenkins/Windows.