### PR TITLE
SLING-12600 temporarily limit test runs to linux again

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -6,6 +6,9 @@
           17,
           21
         ],
+        "operatingSystems": [
+            "linux"
+        ],
         "rebuildFrequency": "@daily",
         "additionalMavenParams": "-Dit.startTimeoutSeconds=120",
         "archivePatterns": [


### PR DESCRIPTION
until we find the root cause of the test flakyness with windows