### PR TITLE
chore: use version 14-SNAPSHOT for integration tests and test services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.launchpad.integration-tests</artifactId>
-            <version>13</version>
+            <version>14-SNAPSHOT</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/features/test/test-content.json
+++ b/src/main/features/test/test-content.json
@@ -2,7 +2,7 @@
   "id":"${project.groupId}:${project.artifactId}:slingosgifeature:test-content:${project.version}",  
   "bundles":[
     {
-      "id": "org.apache.sling:org.apache.sling.launchpad.test-services:13",
+      "id": "org.apache.sling:org.apache.sling.launchpad.test-services:14-SNAPSHOT",
       "start-order": "25"
     }
   ],


### PR DESCRIPTION
This way new tests and associated services will be picked up.