### PR TITLE
SLING-12367 - MBean platform server not registered for Sling Starter

### DIFF
--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -147,6 +147,10 @@
             "start-order":"5"
         },
         {
+            "id": "org.apache.aries.jmx:org.apache.aries.jmx.mbeanserver-platform:0.0.1",
+            "start-order": "5"
+        },
+        {
             "id":"org.apache.aries.jmx:org.apache.aries.jmx.api:1.1.5",
             "start-order":"5"
         },


### PR DESCRIPTION
Register the MBean Server using the new Aries bundle.