### PR TITLE
SLING-12732 - Migrate Starter tests to Jakarta JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,13 +99,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- provided-scope dependency of the commons.johnzon bundle -->
-        <dependency>
-            <groupId>org.apache.johnzon</groupId>
-            <artifactId>johnzon-core</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/features/test/junit.json
+++ b/src/main/features/test/junit.json
@@ -2,7 +2,7 @@
   "id":"${project.groupId}:${project.artifactId}:slingosgifeature:junit:${project.version}",  
   "bundles":[
     {
-      "id": "org.apache.sling:org.apache.sling.junit.core:1.1.6",
+      "id": "org.apache.sling:org.apache.sling.junit.core:1.2.0",
       "start-order": "25"
     },
     {


### PR DESCRIPTION
- use junit.core compatible with Jakarta JSON
- stop importing Johnzon 1.0 for test JSON support; the latest launchpad testing module brings in Johnzon 2.0