### PR TITLE
SLING-10000 bump to new releases for sling 3.x and jakarta migration

### DIFF
--- a/src/main/features/app/starter.json
+++ b/src/main/features/app/starter.json
@@ -1,7 +1,7 @@
 {
     "bundles": [
         {
-            "id":"org.apache.sling:org.apache.sling.starter.content:1.0.16",
+            "id":"org.apache.sling:org.apache.sling.starter.content:2.0.0-SNAPSHOT",
             "start-order":"20"
         }
     ],

--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -107,7 +107,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.i18n:2.6.6",
+            "id":"org.apache.sling:org.apache.sling.i18n:3.0.0-SNAPSHOT",
             "start-order":"20"
         },
         {
@@ -119,11 +119,11 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.models.api:1.5.4",
+            "id":"org.apache.sling:org.apache.sling.models.api:2.0.0-SNAPSHOT",
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.models.impl:1.7.8",
+            "id":"org.apache.sling:org.apache.sling.models.impl:2.0.0-SNAPSHOT",
             "start-order":"20"
         },
         {
@@ -199,7 +199,7 @@
             "start-order":"5"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.api:3.0.2",
+            "id":"org.apache.sling:org.apache.sling.api:3.0.3-SNAPSHOT",
             "start-order":"5"
         },
         {

--- a/src/main/features/oak/oak_base.json
+++ b/src/main/features/oak/oak_base.json
@@ -134,11 +134,11 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.jcr.jackrabbit.accessmanager:4.0.2",
+            "id":"org.apache.sling:org.apache.sling.jcr.jackrabbit.accessmanager:5.0.0-SNAPSHOT",
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager:2.2.30",
+            "id":"org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager:3.0.0-SNAPSHOT",
             "start-order":"20"
         }
     ],

--- a/src/main/features/scripting.json
+++ b/src/main/features/scripting.json
@@ -58,7 +58,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.scripting.sightly:1.4.28-1.4.0",
+            "id":"org.apache.sling:org.apache.sling.scripting.sightly:2.0.0-1.4.0-SNAPSHOT",
             "start-order":"20"
         },
         {


### PR DESCRIPTION
integrate changes from these related issues:

* org.apache.sling:org.apache.sling.i18n:3.0.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12312
	- https://github.com/apache/sling-org-apache-sling-i18n/pull/18

* org.apache.sling:org.apache.sling.jcr.jackrabbit.accessmanager:5.0.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12868
	- https://github.com/apache/sling-org-apache-sling-jcr-jackrabbit-accessmanager/pull/26

* org.apache.sling:org.apache.sling.starter.content:2.0.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12882
	- https://github.com/apache/sling-org-apache-sling-starter-content/pull/12

* org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager:3.0.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12869
	- https://github.com/apache/sling-org-apache-sling-jcr-jackrabbit-usermanager/pull/26

* org.apache.sling:org.apache.sling.models.api:2.0.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12874
	- https://github.com/apache/sling-org-apache-sling-models-api/pull/16

* org.apache.sling:org.apache.sling.models.impl:2.0.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12875
	- https://github.com/apache/sling-org-apache-sling-models-impl/pull/67

* org.apache.sling:org.apache.sling.scripting.sightly:2.0.0-1.4.0-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12883
	- https://github.com/apache/sling-org-apache-sling-scripting-sightly/pull/35

* org.apache.sling:org.apache.sling.api:3.0.3-SNAPSHOT
	- https://issues.apache.org/jira/browse/SLING-12877
	- https://github.com/apache/sling-org-apache-sling-api/pull/66