### PR TITLE
chore: remove global 'stopMode' configuration for the docker-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,6 @@
                 <configuration>
                     <skip>${docker.skip}</skip>
                     <containerNamePattern>%e</containerNamePattern>
-                    <stopMode>kill</stopMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This is a parameter for the 'image/run' element and its usage currently leads to warnings

[WARNING] Parameter 'stopMode' is unknown for plugin 'docker-maven-plugin:0.46.0:build (build-docker-image)' [WARNING] Parameter 'stopMode' is unknown for plugin 'docker-maven-plugin:0.46.0:push (build-docker-image)' [WARNING] Parameter 'stopMode' is unknown for plugin 'docker-maven-plugin:0.46.0:start (start-mongo)' [WARNING] Parameter 'stopMode' is unknown for plugin 'docker-maven-plugin:0.46.0:stop (stop-mongo)'

Let's remove it for now and, if needed, add it back on a per-image basis.