### PR TITLE
SLING-13246 allow a Content-Type response header with a charset

### DIFF
--- a/src/test/java/org/apache/sling/starter/SmokeIT.java
+++ b/src/test/java/org/apache/sling/starter/SmokeIT.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.felix.utils.json.JSONParser;
@@ -198,7 +199,9 @@ public class SmokeIT {
                 }
 
                 Header contentType = response.getFirstHeader("Content-Type");
-                assertThat("Content-Type header", contentType.getValue(), equalTo("text/xml"));
+                assertThat(
+                        "Content-Type header",
+                        Pattern.matches("^text\\/xml(;\\s*charset=.*)?$", contentType.getValue()));
 
                 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
                 dbf.setNamespaceAware(true);


### PR DESCRIPTION
Update SmokeIT to allow a Content-Type response header with a charset

The latest versions of jetty are appending the charset to the Content-Type header of the response.

The result is the following assertion failing in the smote test.  Fix by adjusting the value matching to allow an optional charset suffix.

`SmokeIT.ensureRepositoryIsStarted:201 Content-Type header Expected: "text/xml" but: was "text/xml;charset=utf-8"`