### PR TITLE
SLING-13258 - Sling Starter GitHub actions fail: docker/login-action@... is not allowed

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'maven'
       - name: Login to Docker Hub
         id: login-docker-hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'maven'
       - name: Login to Docker Hub
         id: login-docker-hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Switch to versions supported by https://github.com/apache/infrastructure-actions