### PR TITLE
Fix unapproved docker/setup-buildx-action SHA in GH workflows

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Set up QEMU # https://github.com/docker/buildx/issues/499
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Push Docker image
         run: mvn --batch-mode clean install -Ddocker.platforms=linux/amd64,linux/arm64 -Dmaven.test.skip=true -Ddocker.skip=false -Ddocker.skip.push=false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up QEMU # https://github.com/docker/buildx/issues/499
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Push Docker image
         run: |
           version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)


### PR DESCRIPTION
The pinned SHA for docker/setup-buildx-action was dropped from the ASF INFRA GitHub Actions allowlist, causing docker-push.yml and docker-release.yml to fail with startup_failure. Repin to the currently approved v4.2.0 SHA.