### PR TITLE
chore(deps): configure renovate to create separate PRs for each minor MongoDB version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,13 @@
       ]
     },
     {
+      "groupName": "MongoDB Java Driver",
+      "matchPackageNames": [
+        "org.mongodb:{/,}**"
+      ],
+      "separateMultipleMinor": true
+    },
+    {
       "matchManagers": [
         "maven"
       ],


### PR DESCRIPTION
Oak is pretty conservative about using newer MongoDB driver versions so using the latest one usually does not work.